### PR TITLE
Add dark mode support with theme context and toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,9 @@
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "18"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { PlaybackProvider } from "@/contexts/PlaybackContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import { PlayerBar } from "@/components/PlayerBar";
 import Index from "./pages/Index";
 import Song from "./pages/Song";
@@ -25,20 +26,22 @@ const App = () => {
   
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <PlaybackProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/song/:id" element={<Song />} />
-              <Route path="/profile/:address" element={<Profile />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </PlaybackProvider>
-        <Toaster />
-        <Sonner />
-      </TooltipProvider>
+      <ThemeProvider>
+        <TooltipProvider>
+          <PlaybackProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/song/:id" element={<Song />} />
+                <Route path="/profile/:address" element={<Profile />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </PlaybackProvider>
+          <Toaster />
+          <Sonner />
+        </TooltipProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 };

--- a/src/components/FarcasterConnection.tsx
+++ b/src/components/FarcasterConnection.tsx
@@ -20,42 +20,42 @@ export const FarcasterConnection = ({ onConnect }: FarcasterConnectionProps) => 
   };
 
   return (
-    <Card className="w-full max-w-md border-2 border-taco-black bg-white">
-      <CardHeader className="text-center border-b-2 border-taco-black">
-        <div className="w-16 h-16 bg-gradient-to-br from-purple-600 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
-          <User className="w-8 h-8 text-white" />
+    <Card className="w-full max-w-md border border-border bg-card">
+      <CardHeader className="text-center border-b border-border">
+        <div className="w-16 h-16 bg-accent rounded-full flex items-center justify-center mx-auto mb-4">
+          <User className="w-8 h-8 text-accent-foreground" />
         </div>
-        <CardTitle className="taco-subheading text-taco-black mb-2">
+        <CardTitle className="font-mono font-bold text-card-foreground mb-2 text-xl">
           Sign In with Farcaster
         </CardTitle>
-        <p className="taco-ui-text text-taco-dark-grey">
+        <p className="font-mono text-muted-foreground">
           Connect with your Farcaster identity to discover music through your social network
         </p>
       </CardHeader>
       
       <CardContent className="p-6 space-y-6">
         <div className="space-y-4">
-          <div className="flex items-center gap-3 p-3 border-2 border-taco-black bg-taco-light-grey">
-            <User className="w-5 h-5 text-taco-black flex-shrink-0" />
+          <div className="flex items-center gap-3 p-3 border border-border bg-secondary">
+            <User className="w-5 h-5 text-accent flex-shrink-0" />
             <div>
-              <p className="taco-ui-text font-bold text-taco-black text-sm">Social Discovery</p>
-              <p className="taco-ui-text text-taco-dark-grey text-xs">Find music through your Farcaster network</p>
+              <p className="font-mono font-bold text-secondary-foreground text-sm">Social Discovery</p>
+              <p className="font-mono text-muted-foreground text-xs">Find music through your Farcaster network</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-3 p-3 border-2 border-taco-black bg-taco-light-grey">
-            <Shield className="w-5 h-5 text-taco-black flex-shrink-0" />
+          <div className="flex items-center gap-3 p-3 border border-border bg-secondary">
+            <Shield className="w-5 h-5 text-accent flex-shrink-0" />
             <div>
-              <p className="taco-ui-text font-bold text-taco-black text-sm">Secure & Private</p>
-              <p className="taco-ui-text text-taco-dark-grey text-xs">Your Farcaster identity verifies ownership</p>
+              <p className="font-mono font-bold text-secondary-foreground text-sm">Secure & Private</p>
+              <p className="font-mono text-muted-foreground text-xs">Your Farcaster identity verifies ownership</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-3 p-3 border-2 border-taco-black bg-taco-light-grey">
-            <Zap className="w-5 h-5 text-taco-black flex-shrink-0" />
+          <div className="flex items-center gap-3 p-3 border border-border bg-secondary">
+            <Zap className="w-5 h-5 text-accent flex-shrink-0" />
             <div>
-              <p className="taco-ui-text font-bold text-taco-black text-sm">Native Integration</p>
-              <p className="taco-ui-text text-taco-dark-grey text-xs">Share playlists as Farcaster casts</p>
+              <p className="font-mono font-bold text-secondary-foreground text-sm">Native Integration</p>
+              <p className="font-mono text-muted-foreground text-xs">Share playlists as Farcaster casts</p>
             </div>
           </div>
         </div>
@@ -63,28 +63,28 @@ export const FarcasterConnection = ({ onConnect }: FarcasterConnectionProps) => 
         <Button 
           onClick={handleConnect}
           disabled={isLoading}
-          className="w-full taco-button py-4 text-lg bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 border-none"
+          className="w-full font-mono font-bold py-4 text-lg bg-accent text-accent-foreground hover:bg-accent/90"
         >
           {isLoading ? (
             <>
               <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mr-3" />
-              <span className="taco-ui-text text-white">CONNECTING...</span>
+              CONNECTING...
             </>
           ) : (
             <>
               <User className="w-5 h-5 mr-3" />
-              <span className="taco-ui-text text-white">SIGN IN WITH FARCASTER</span>
+              SIGN IN WITH FARCASTER
             </>
           )}
         </Button>
         
-        <p className="taco-ui-text text-taco-dark-grey text-center text-sm">
+        <p className="font-mono text-muted-foreground text-center text-sm">
           New to Farcaster?{" "}
           <a 
             href="https://warpcast.com" 
             target="_blank" 
             rel="noopener noreferrer" 
-            className="text-purple-600 font-bold hover:text-purple-700 transition-colors underline"
+            className="text-accent font-bold hover:text-accent/80 transition-colors underline"
           >
             Join here
           </a>

--- a/src/components/NavigationSimple.tsx
+++ b/src/components/NavigationSimple.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Music, Upload, User, LogOut, ExternalLink } from "lucide-react";
 import { useFarcasterAuth } from "@/hooks/useFarcasterAuth";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface NavigationSimpleProps {
   activeView: "feed" | "upload" | "profile";
@@ -17,15 +18,15 @@ export const NavigationSimple = ({
   const { user, isConnected } = useFarcasterAuth();
 
   return (
-    <nav className="border-b-2 border-taco-black bg-white sticky top-0 z-50">
+    <nav className="border-b border-border bg-background sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-gradient-to-br from-purple-600 to-blue-600 rounded-full flex items-center justify-center">
-              <Music className="w-5 h-5 text-white" />
+            <div className="w-8 h-8 bg-accent rounded-full flex items-center justify-center">
+              <Music className="w-5 h-5 text-accent-foreground" />
             </div>
-            <h1 className="taco-subheading text-taco-black">SoundProof</h1>
+            <h1 className="font-mono font-bold text-foreground text-lg">SoundProof</h1>
           </div>
           
           {/* Navigation */}
@@ -35,11 +36,7 @@ export const NavigationSimple = ({
                 variant={activeView === "feed" ? "default" : "ghost"} 
                 size="sm" 
                 onClick={() => onViewChange("feed")}
-                className={`taco-ui-text ${
-                  activeView === "feed" 
-                    ? "bg-purple-600 text-white hover:bg-purple-700" 
-                    : "hover:bg-taco-light-grey"
-                }`}
+                className="font-mono"
               >
                 <Music className="w-4 h-4 mr-2" />
                 Feed
@@ -49,11 +46,7 @@ export const NavigationSimple = ({
                 variant={activeView === "upload" ? "default" : "ghost"} 
                 size="sm" 
                 onClick={() => onViewChange("upload")}
-                className={`taco-ui-text ${
-                  activeView === "upload" 
-                    ? "bg-purple-600 text-white hover:bg-purple-700" 
-                    : "hover:bg-taco-light-grey"
-                }`}
+                className="font-mono"
               >
                 <Upload className="w-4 h-4 mr-2" />
                 Upload
@@ -63,11 +56,7 @@ export const NavigationSimple = ({
                 variant={activeView === "profile" ? "default" : "ghost"} 
                 size="sm" 
                 onClick={() => onViewChange("profile")}
-                className={`taco-ui-text ${
-                  activeView === "profile" 
-                    ? "bg-purple-600 text-white hover:bg-purple-700" 
-                    : "hover:bg-taco-light-grey"
-                }`}
+                className="font-mono"
               >
                 <User className="w-4 h-4 mr-2" />
                 Profile
@@ -84,26 +73,27 @@ export const NavigationSimple = ({
                   <img
                     src={user.pfp.url}
                     alt={user.displayName}
-                    className="w-8 h-8 rounded-full border-2 border-taco-black"
+                    className="w-8 h-8 rounded-full border border-border"
                     onError={(e) => {
                       const target = e.target as HTMLImageElement;
                       target.style.display = 'none';
                     }}
                   />
                 )}
-                <div className="text-sm">
-                  <div className="font-bold text-taco-black">{user.displayName}</div>
-                  <div className="text-taco-dark-grey">@{user.username}</div>
+                <div className="text-sm font-mono">
+                  <div className="font-bold text-foreground">{user.displayName}</div>
+                  <div className="text-muted-foreground">@{user.username}</div>
                 </div>
               </div>
 
               {/* Actions */}
               <div className="flex items-center gap-2">
+                <ThemeToggle />
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={() => window.open(`https://warpcast.com/${user.username}`, '_blank')}
-                  className="border-2 border-taco-black"
+                  className="font-mono"
                 >
                   <ExternalLink className="w-4 h-4" />
                 </Button>
@@ -112,7 +102,7 @@ export const NavigationSimple = ({
                   variant="outline"
                   size="sm"
                   onClick={onDisconnect}
-                  className="border-2 border-taco-black text-red-600 hover:bg-red-50"
+                  className="font-mono text-destructive hover:bg-destructive/10"
                 >
                   <LogOut className="w-4 h-4" />
                 </Button>
@@ -120,7 +110,8 @@ export const NavigationSimple = ({
             </div>
           ) : (
             <div className="flex items-center gap-2">
-              <span className="text-sm text-taco-dark-grey">Not signed in</span>
+              <ThemeToggle />
+              <span className="text-sm font-mono text-muted-foreground">Not signed in</span>
             </div>
           )}
         </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Button } from '@/components/ui/button';
+
+export const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={toggleTheme}
+      className="h-8 w-8 p-0 font-mono"
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'dark' | 'light';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark' || stored === 'light') {
+      return stored;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -12,14 +12,7 @@
 
 @layer base {
   :root {
-    /* TACo Brand Colors */
-    --taco-black: #000000;
-    --taco-white: #FFFFFF;
-    --taco-neon-green: #96FF5E;
-    --taco-light-grey: #F4F4F4;
-    --taco-dark-grey: #909090;
-    
-    /* Design system mapping */
+    /* Minimal Color Scheme - Light Mode */
     --background: 0 0% 100%;
     --foreground: 0 0% 0%;
 
@@ -32,21 +25,22 @@
     --primary: 0 0% 0%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 95.8%;
+    --secondary: 0 0% 96%;
     --secondary-foreground: 0 0% 0%;
 
-    --muted: 0 0% 95.8%;
-    --muted-foreground: 0 0% 56.5%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 45%;
 
-    --accent: 84 100% 67%;
-    --accent-foreground: 0 0% 0%;
+    /* Vibrant Orange Accent */
+    --accent: 24 100% 50%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 0%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 24 100% 50%;
 
     --radius: 0.5rem;
 
@@ -54,49 +48,51 @@
     --sidebar-foreground: 0 0% 15%;
     --sidebar-primary: 0 0% 0%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 95.8%;
+    --sidebar-accent: 0 0% 96%;
     --sidebar-accent-foreground: 0 0% 0%;
-    --sidebar-border: 0 0% 89.8%;
-    --sidebar-ring: 0 0% 0%;
+    --sidebar-border: 0 0% 90%;
+    --sidebar-ring: 24 100% 50%;
   }
 
   .dark {
-    --background: 0 0% 0%;
-    --foreground: 0 0% 100%;
+    /* Minimal Color Scheme - Dark Mode */
+    --background: 0 0% 3%;
+    --foreground: 0 0% 98%;
 
-    --card: 0 0% 0%;
-    --card-foreground: 0 0% 100%;
+    --card: 0 0% 3%;
+    --card-foreground: 0 0% 98%;
 
-    --popover: 0 0% 0%;
-    --popover-foreground: 0 0% 100%;
+    --popover: 0 0% 3%;
+    --popover-foreground: 0 0% 98%;
 
-    --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 0%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 3%;
 
-    --secondary: 0 0% 5%;
-    --secondary-foreground: 0 0% 100%;
+    --secondary: 0 0% 8%;
+    --secondary-foreground: 0 0% 98%;
 
-    --muted: 0 0% 5%;
-    --muted-foreground: 0 0% 56.5%;
+    --muted: 0 0% 8%;
+    --muted-foreground: 0 0% 65%;
 
-    --accent: 84 100% 67%;
-    --accent-foreground: 0 0% 0%;
+    /* Vibrant Orange Accent */
+    --accent: 24 100% 50%;
+    --accent-foreground: 0 0% 98%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 100%;
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 0 0% 10%;
-    --input: 0 0% 10%;
-    --ring: 0 0% 100%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 24 100% 50%;
 
-    --sidebar-background: 0 0% 2%;
+    --sidebar-background: 0 0% 1%;
     --sidebar-foreground: 0 0% 95%;
-    --sidebar-primary: 0 0% 100%;
-    --sidebar-primary-foreground: 0 0% 0%;
-    --sidebar-accent: 0 0% 5%;
-    --sidebar-accent-foreground: 0 0% 100%;
-    --sidebar-border: 0 0% 10%;
-    --sidebar-ring: 0 0% 100%;
+    --sidebar-primary: 0 0% 98%;
+    --sidebar-primary-foreground: 0 0% 3%;
+    --sidebar-accent: 0 0% 8%;
+    --sidebar-accent-foreground: 0 0% 98%;
+    --sidebar-border: 0 0% 15%;
+    --sidebar-ring: 24 100% 50%;
   }
 }
 
@@ -160,17 +156,17 @@
     letter-spacing: 0.1em;
   }
 
-  /* Neon green accent utility */
-  .text-neon {
-    color: #96FF5E;
+  /* Vibrant orange accent utility */
+  .text-accent {
+    color: hsl(24 100% 50%);
   }
 
-  .bg-neon {
-    background-color: #96FF5E;
+  .bg-accent {
+    background-color: hsl(24 100% 50%);
   }
 
-  .border-neon {
-    border-color: #96FF5E;
+  .border-accent {
+    border-color: hsl(24 100% 50%);
   }
 
   /* Grid background pattern like in the image */
@@ -190,17 +186,17 @@
   }
 
   .taco-button:hover {
-    @apply bg-neon text-black border-neon;
+    @apply bg-accent text-white border-accent;
   }
 
   .taco-button-accent {
-    @apply bg-neon text-black border-2 border-neon font-bold uppercase tracking-wider;
+    @apply bg-accent text-white border-2 border-accent font-bold uppercase tracking-wider;
     font-family: 'IBM Plex Mono', monospace;
     font-weight: 700;
     transition: all 0.2s ease;
   }
 
   .taco-button-accent:hover {
-    @apply bg-black text-neon;
+    @apply bg-primary text-accent;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import { FarcasterUsernameModal } from "@/components/FarcasterUsernameModal";
 import { NavigationSimple } from "@/components/NavigationSimple";
 import { PlayerBar } from "@/components/PlayerBar";
 import { PlaybackProvider } from "@/contexts/PlaybackContext";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { useFarcasterAuth } from "@/hooks/useFarcasterAuth";
 import { getFarcasterClient } from "@/integrations/farcaster/client";
 import { Shield, User, Zap, Music } from "lucide-react";
@@ -71,13 +72,16 @@ const Index = () => {
       </div>;
     }
 
-    return <div className="min-h-screen bg-white grid-background">
+    return <div className="min-h-screen bg-background">
+        <div className="absolute top-4 right-4">
+          <ThemeToggle />
+        </div>
         <div className="container mx-auto px-4 py-16">
           <div className="max-w-4xl mx-auto space-y-16">
             {/* Hero Section */}
             <div className="text-center space-y-6">
-              <h1 className="taco-banner text-taco-black">SOUND PROOF</h1>
-              <p className="taco-body text-taco-dark-grey max-w-2xl mx-auto">
+              <h1 className="text-4xl md:text-6xl font-mono font-bold text-foreground uppercase tracking-wider">SOUND PROOF</h1>
+              <p className="text-lg font-mono text-muted-foreground max-w-2xl mx-auto">
                 Discover tomorrow's artists today. Pay once, own forever. 
                 Music discovery powered by your Farcaster social network.
               </p>
@@ -89,42 +93,42 @@ const Index = () => {
             </div>
 
             {/* About SoundProof */}
-            <Card className="border-2 border-taco-black bg-white">
-              <CardHeader className="border-b-2 border-taco-black">
+            <Card className="border border-border bg-card">
+              <CardHeader className="border-b border-border">
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 bg-gradient-to-br from-purple-600 to-blue-600 rounded-full flex items-center justify-center">
-                    <Music className="w-6 h-6 text-white" />
+                  <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center">
+                    <Music className="w-6 h-6 text-accent-foreground" />
                   </div>
-                  <CardTitle className="taco-subheading text-taco-black">
+                  <CardTitle className="font-mono font-bold text-card-foreground text-xl">
                     Social Music Discovery
                   </CardTitle>
                 </div>
               </CardHeader>
               <CardContent className="p-6 space-y-4">
-                <p className="taco-ui-text text-taco-black">
+                <p className="font-mono text-card-foreground">
                   <strong>SoundProof</strong> leverages your Farcaster social network to help you discover 
                   incredible music from tomorrow's artists. Pay once, own forever.
                 </p>
                 <div className="grid md:grid-cols-3 gap-4">
-                  <div className="flex items-start gap-3 p-4 border border-taco-black bg-taco-light-grey">
-                    <User className="w-5 h-5 text-taco-black mt-1 flex-shrink-0" />
+                  <div className="flex items-start gap-3 p-4 border border-border bg-secondary">
+                    <User className="w-5 h-5 text-accent mt-1 flex-shrink-0" />
                     <div>
-                      <p className="taco-ui-text font-bold text-taco-black">Friend Discovery</p>
-                      <p className="taco-ui-text text-taco-dark-grey text-sm">Find music through your Farcaster social graph and friends' activity</p>
+                      <p className="font-mono font-bold text-secondary-foreground">Friend Discovery</p>
+                      <p className="font-mono text-muted-foreground text-sm">Find music through your Farcaster social graph and friends' activity</p>
                     </div>
                   </div>
-                  <div className="flex items-start gap-3 p-4 border border-taco-black bg-taco-light-grey">
-                    <Zap className="w-5 h-5 text-taco-black mt-1 flex-shrink-0" />
+                  <div className="flex items-start gap-3 p-4 border border-border bg-secondary">
+                    <Zap className="w-5 h-5 text-accent mt-1 flex-shrink-0" />
                     <div>
-                      <p className="taco-ui-text font-bold text-taco-black">3¢ TrackPass</p>
-                      <p className="taco-ui-text text-taco-dark-grey text-sm">Pay once with bonding curve pricing, own the track forever</p>
+                      <p className="font-mono font-bold text-secondary-foreground">3¢ TrackPass</p>
+                      <p className="font-mono text-muted-foreground text-sm">Pay once with bonding curve pricing, own the track forever</p>
                     </div>
                   </div>
-                  <div className="flex items-start gap-3 p-4 border border-taco-black bg-taco-light-grey">
-                    <Shield className="w-5 h-5 text-taco-black mt-1 flex-shrink-0" />
+                  <div className="flex items-start gap-3 p-4 border border-border bg-secondary">
+                    <Shield className="w-5 h-5 text-accent mt-1 flex-shrink-0" />
                     <div>
-                      <p className="taco-ui-text font-bold text-taco-black">90% to Artists</p>
-                      <p className="taco-ui-text text-taco-dark-grey text-sm">Direct support to emerging musicians with transparent revenue split</p>
+                      <p className="font-mono font-bold text-secondary-foreground">90% to Artists</p>
+                      <p className="font-mono text-muted-foreground text-sm">Direct support to emerging musicians with transparent revenue split</p>
                     </div>
                   </div>
                 </div>
@@ -132,61 +136,61 @@ const Index = () => {
             </Card>
 
             {/* About Platform */}
-            <Card className="border-2 border-taco-black bg-white">
-              <CardHeader className="border-b-2 border-taco-black">
+            <Card className="border border-border bg-card">
+              <CardHeader className="border-b border-border">
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 bg-gradient-to-br from-purple-600 to-blue-600 rounded-full flex items-center justify-center">
-                    <Music className="w-6 h-6 text-white" />
+                  <div className="w-12 h-12 bg-accent rounded-full flex items-center justify-center">
+                    <Music className="w-6 h-6 text-accent-foreground" />
                   </div>
-                  <CardTitle className="taco-subheading text-taco-black">
+                  <CardTitle className="font-mono font-bold text-card-foreground text-xl">
                     Powered by Farcaster + TACo
                   </CardTitle>
                 </div>
               </CardHeader>
               <CardContent className="p-6 space-y-4">
-                <p className="taco-ui-text text-taco-black">
+                <p className="font-mono text-card-foreground">
                   <strong>SoundProof</strong> combines Farcaster's social protocol with TACo encryption 
                   to create the first truly social music discovery platform.
                 </p>
                 <div className="grid md:grid-cols-2 gap-4">
                   <div className="space-y-3">
-                    <p className="taco-ui-text font-bold text-taco-black">Social Features:</p>
+                    <p className="font-mono font-bold text-card-foreground">Social Features:</p>
                     <ul className="space-y-2">
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-purple-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Friend-based discovery
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-purple-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Playlist sharing as casts
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-purple-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Native tipping support
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-purple-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Music community channels
                       </li>
                     </ul>
                   </div>
                   <div className="space-y-3">
-                    <p className="taco-ui-text font-bold text-taco-black">Perfect for:</p>
+                    <p className="font-mono font-bold text-card-foreground">Perfect for:</p>
                     <ul className="space-y-2">
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Bedroom producers
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Music crate-diggers
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Playlist curators
                       </li>
-                      <li className="taco-ui-text text-taco-dark-grey flex items-center gap-2">
-                        <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
+                      <li className="font-mono text-muted-foreground flex items-center gap-2">
+                        <div className="w-2 h-2 bg-accent rounded-full"></div>
                         Underground music fans
                       </li>
                     </ul>
@@ -197,11 +201,11 @@ const Index = () => {
 
             {/* Call to Action */}
             <div className="text-center">
-              <p className="taco-body text-taco-dark-grey mb-6">
+              <p className="font-mono text-muted-foreground mb-6 text-lg">
                 Ready to discover tomorrow's artists today?
               </p>
-              <Button onClick={handleFarcasterConnect} className="taco-button px-8 py-4 text-lg bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 border-none">
-                <span className="taco-ui-text text-white">GET STARTED</span>
+              <Button onClick={handleFarcasterConnect} className="px-8 py-4 text-lg font-mono font-bold bg-accent text-accent-foreground hover:bg-accent/90">
+                GET STARTED
               </Button>
             </div>
           </div>
@@ -259,7 +263,7 @@ const Index = () => {
       </div>;
   }
   return <PlaybackProvider>
-      <div className="min-h-screen bg-white grid-background text-black pb-24">
+      <div className="min-h-screen bg-background text-foreground pb-24">
         <NavigationSimple activeView={activeView} onViewChange={setActiveView} userAddress={user?.fid.toString() || ''} onDisconnect={signOut} />
         
         <main className="container mx-auto px-4 py-8">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,12 +25,8 @@ export default {
 				'sans': ['IBM Plex Mono', 'monospace'],
 			},
 			colors: {
-				// TACo Brand Colors
-				'taco-black': '#000000',
-				'taco-white': '#FFFFFF',
-				'taco-neon': '#96FF5E',
-				'taco-light-grey': '#F4F4F4',
-				'taco-dark-grey': '#909090',
+				// Minimal Color Scheme
+				'orange': '#FF6600',
 				
 				// Design system
 				border: 'hsl(var(--border))',


### PR DESCRIPTION
## Summary
- Introduces dark mode support with a new ThemeContext and ThemeProvider
- Adds a ThemeToggle component for switching between light and dark themes
- Updates UI components and styles for consistent dark mode appearance
- Refactors color variables and utility classes to support both light and dark themes
- Wraps the app with ThemeProvider to enable theme context globally

## Changes

### Theme Context and Provider
- Created `ThemeContext` with `theme` state and `toggleTheme` function
- `ThemeProvider` manages theme state, persists preference in localStorage, and applies CSS classes to document root
- Added `useTheme` hook for easy access to theme context

### Theme Toggle Component
- New `ThemeToggle` button component using lucide-react icons (Sun and Moon)
- Toggles theme on click and updates UI accordingly

### UI and Styling Updates
- Updated `index.css` with CSS variables for light and dark themes
- Replaced old TACo brand colors with minimal color scheme and vibrant orange accent
- Updated components (`FarcasterConnection`, `NavigationSimple`, `Index`, etc.) to use new color variables and font styles
- Added `ThemeToggle` button in navigation and index page
- Adjusted borders, backgrounds, and text colors for dark mode consistency

### App Integration
- Wrapped app in `ThemeProvider` in `App.tsx` to provide theme context

## Test plan
- [x] Verify theme toggling between light and dark modes
- [x] Check UI components render correctly in both themes
- [x] Confirm theme preference persists across page reloads
- [x] Ensure no visual regressions in navigation, connection cards, and main pages
- [x] Test accessibility of theme toggle button

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a31d99f8-baa3-49fc-9033-277c3365a139